### PR TITLE
High-level API to define custom protocol based on foglet

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -27,14 +27,16 @@ module.exports = function (config) {
       'tests/fbroadcastTest.js',
       // 'tests/finterpreterTest.js',
       'tests/fstoreTest.js',
-      'tests/middleware-test.js'
+      'tests/middleware-test.js',
+      'tests/fprotocol/*-test.js'
     ],
     preprocessors:{
       'tests/fogletTest.js': [ 'coverage', 'browserify' ],
       'tests/fbroadcastTest.js': [ 'coverage', 'browserify' ],
       // 'tests/finterpreterTest.js' : [ 'coverage', 'browserify' ],
       'tests/fstoreTest.js': [ 'coverage', 'browserify' ],
-      'tests/middleware-test.js': [ 'coverage', 'browserify' ]
+      'tests/middleware-test.js': [ 'coverage', 'browserify' ],
+      'tests/fprotocol/*-test.js': [ 'coverage', 'browserify' ]
     },
     // list of files to exclude
     exclude: [
@@ -47,12 +49,12 @@ module.exports = function (config) {
       transform: [ [ 'babelify', {presets: [ 'es2015' ]} ], 'browserify-istanbul' ]
     },
     extensions: [ '.js' ],
-    proxies : {
+    proxies: {
       './': 'http://localhost:3000'
     },
-    port:3001,
+    port: 3001,
     expressHttpServer: {
-      port:4001,
+      port: 4001,
       // this function takes express app object and allows you to modify it
       // to your liking. For more see http://expressjs.com/4x/api.html
       appVisitor: signaling
@@ -80,7 +82,7 @@ module.exports = function (config) {
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     autoWatch: true,
-    browserNoActivityTimeout:50000,
+    browserNoActivityTimeout: 50000,
     colors: true,
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG

--- a/src/fprotocol/answer-queue.js
+++ b/src/fprotocol/answer-queue.js
@@ -52,19 +52,27 @@ class AnswerQueue {
   }
 
   /**
-   * Resolve an answer
+   * Resolve the answer to a message
    * @param {string} answerID - The id of the answer to resolve
-   * @param {string} type - The answer's type (reply or reject)
    * @param {*} payload - The answer's content
    * @return {void}
    */
-  resolve (answerID, type, payload) {
+  resolve (answerID, payload) {
     if (this._waitingAnswers.has(answerID)) {
-      if (type === 'reply') {
-        this._waitingAnswers.get(answerID).resolve(payload);
-      } else if (type === 'reject') {
-        this._waitingAnswers.get(answerID).reject(payload);
-      }
+      this._waitingAnswers.get(answerID).resolve(payload);
+      this._waitingAnswers.delete(answerID);
+    }
+  }
+
+  /**
+   * Resolve an answer by a reject
+   * @param {string} answerID - The id of the answer to reject
+   * @param {*} payload - The answer's content
+   * @return {void}
+   */
+  reject (answerID, payload) {
+    if (this._waitingAnswers.has(answerID)) {
+      this._waitingAnswers.get(answerID).reject(payload);
       this._waitingAnswers.delete(answerID);
     }
   }

--- a/src/fprotocol/answer-queue.js
+++ b/src/fprotocol/answer-queue.js
@@ -1,0 +1,73 @@
+/*
+MIT License
+
+Copyright (c) 2016-2017 Grall Arnaud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+'use strict';
+
+const uuid = require('uuid/v4');
+
+/**
+ * An AnswerQueue stamp messages with unique ids and allow peers to answer to service calls
+ * using the `reply` and `reject` helpers.
+ * @author Thomas Minier
+ */
+class AnswerQueue {
+  /**
+   * Constructor
+   */
+  constructor () {
+    this._waitingAnswers = new Map();
+  }
+
+  /**
+   * Stamp a message and connect to a promise resolved with it answer
+   * @param {Object} message - The message to stamp
+   * @param {function} resolve - The function used to resolve the promise when the answer is received
+   * @param {function} reject - The function used to reject the promise when the answer is received
+   * @return {Object} The stamped message
+   */
+  stamp (message, resolve, reject) {
+    const answerID = uuid();
+    this._waitingAnswers.set(answerID, { resolve, reject });
+    return Object.assign({ answerID }, message);
+  }
+
+  /**
+   * Resolve an answer
+   * @param {string} answerID - The id of the answer to resolve
+   * @param {string} type - The answer's type (reply or reject)
+   * @param {*} payload - The answer's content
+   * @return {void}
+   */
+  resolve (answerID, type, payload) {
+    if (this._waitingAnswers.has(answerID)) {
+      if (type === 'reply') {
+        this._waitingAnswers.get(answerID).resolve(payload);
+      } else if (type === 'reject') {
+        this._waitingAnswers.get(answerID).reject(payload);
+      }
+      this._waitingAnswers.delete(answerID);
+    }
+  }
+}
+
+module.exports = AnswerQueue;

--- a/src/fprotocol/example.js
+++ b/src/fprotocol/example.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const FogletResource = require('./foglet-resource.js');
+
+// get foglet instance from somewhere
+const foglet = null;
+
+class EventsResource extends FogletResource {
+  constructor (foglet) {
+    super('events', foglet);
+    this._events = [];
+  }
+
+  _get (reply, reject) {
+    if (this._events.length === 0)
+      reject('No events to send');
+    reply(this._events);
+  }
+
+  _post (msg, reply) {
+    this._events.push(msg.newEvent);
+    reply('insert done');
+  }
+
+  _patch (msg, reply) {
+    this._events[msg.index] = msg.updatedEvent;
+    reply('update done');
+  }
+
+  _delete (msg, reply) {
+    this._events.splice(msg.index, 1);
+    reply('delete done');
+  }
+}
+
+const events = new EventsResource(foglet);
+
+const someID = 'aaa-12-bb-28'; // the id of some remote foglet using the same protocol
+
+events.get(someID)
+.then(res => {
+  console.log(res);
+  events.post(someID, { newEvent: 'save the world!' });
+})
+.then(() => events.get())
+.then(res => {
+  console.log(res);
+  events.patch(someID, { index: 0, updatedEvent: 'save the world (only on sunday)!' });
+})
+.then(res => {
+  console.log(res);
+  events.delete(someID, { index: 0 });
+})
+.then(res => {
+  console.log(res);
+  events.get(someID);
+})
+.then(console.log);

--- a/src/fprotocol/foglet-protocol.js
+++ b/src/fprotocol/foglet-protocol.js
@@ -1,0 +1,65 @@
+/*
+MIT License
+
+Copyright (c) 2016-2017 Grall Arnaud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+'use strict';
+
+const merge = require('lodash/merge');
+
+/**
+ * FogletProtcol represent an abstract protocol.
+ *
+ * A Protocol is a a set of behaviours used to interact with others foglet that shares the same protocol.
+ * It contains:
+ * * rules, i.e. anonymous functions, to execute when receving specific message (by unicast and/or broadcast)
+ * *
+ * @abstract
+ * @author Thomas Minier
+ */
+class FogletProtcol {
+  constructor (name, foglet) {
+    this._name = name;
+    this._foglet = foglet;
+  }
+
+  namespace (name) {
+    return {
+      unicast: new UnicastServiceSetup(this, name),
+      broadcast: new BroadCastServiceSetup(this, name)
+    };
+  }
+}
+
+class UnicastServiceSetup {
+  constructor (protocol, namespace) {
+    this._protocol = protocol;
+    this._namespace = namespace;
+  }
+
+  service (name, handler) {
+    this._protocol._registerUnicastHandler(`${this.namespace}/${name}`, handler);
+    // return this for chained calls
+    return this;
+  }
+}
+
+module.exports = FogletProtcol;

--- a/src/fprotocol/foglet-protocol.js
+++ b/src/fprotocol/foglet-protocol.js
@@ -38,6 +38,20 @@ const HandlerManager = require('./handler-manager.js');
  * For example, a service **get** requires to define a method named **_get** in the subclass.
  * @abstract
  * @author Thomas Minier
+ * @example
+ * class SimpleUnicastProtocol extends FogletProtocol {
+
+   _unicast () {
+     return [ 'get' ];
+   }
+
+   _get (msg, reply, reject) {
+     if (msg.number % 2 === 0)
+        reply('you send an event number');
+     else
+        reject('you send an event number, it is not good!!!');
+   }
+ }
  */
 class FogletProtocol {
   /**

--- a/src/fprotocol/foglet-protocol.js
+++ b/src/fprotocol/foglet-protocol.js
@@ -74,8 +74,24 @@ class FogletProtocol {
     return [];
   }
 
-  _answer (msg) {
-    this._answerQueue.resolve(msg.answerID, msg.type, msg.value);
+  /**
+   * Handler which resolve answers to messages
+   * @private
+   * @param {Object} msg - Answer received
+   * @return{void}
+   */
+  _answerReply (msg) {
+    this._answerQueue.resolve(msg.answerID, msg.value);
+  }
+
+  /**
+   * Handler which reject answers to messages
+   * @private
+   * @param {Object} msg - Answer received
+   * @return{void}
+   */
+  _answerReject (msg) {
+    this._answerQueue.reject(msg.answerID, msg.value);
   }
 
   /**

--- a/src/fprotocol/foglet-resource.js
+++ b/src/fprotocol/foglet-resource.js
@@ -31,23 +31,23 @@ class FogletResource extends FogletProtocol {
   }
 
   _unicast () {
-    return [ 'get', 'post', 'patch', 'delete' ];
+    return [ 'get', 'insert', 'update', 'delete' ];
   }
 
   _get (msg, reply, reject) {
-    reject(new Error('implement a get method'));
+    reject(new Error('A valid FogletResource must implement a get handler'));
   }
 
-  _post (msg, reply, reject) {
-    reject(new Error('implement a post method'));
+  _insert (msg, reply, reject) {
+    reject(new Error('A valid FogletResource must implement an insert handler'));
   }
 
-  _patch (msg, reply, reject) {
-    reject(new Error('implement a patch method'));
+  _update (msg, reply, reject) {
+    reject(new Error('A valid FogletResource must implement an update handler'));
   }
 
   _delete (msg, reply, reject) {
-    reject(new Error('implement a delete method'));
+    reject(new Error('A valid FogletResource must implement a delete handler'));
   }
 }
 

--- a/src/fprotocol/foglet-resource.js
+++ b/src/fprotocol/foglet-resource.js
@@ -23,25 +23,15 @@ SOFTWARE.
 */
 'use strict';
 
-const FogletProtcol = require('./foglet-protocol.js');
+const FogletProtocol = require('./foglet-protocol.js');
 
-class FogletResource extends FogletProtcol {
+class FogletResource extends FogletProtocol {
   constructor (name, foglet) {
-    super(foglet);
-    this._namespace = `resource/${name}`;
-    this.unicast()
-    .service('get', this._get)
-    .service('post', this._post)
-    .service('patch', this._patch)
-    .service('delete', this._delete);
+    super(`foglet-core/foglet-resource/${name}`, foglet);
   }
 
-  get (id) {
-    return new Promise((resolve, reject) => {
-      const msgID = someRandomID();
-      this.unicast(id).call('get');
-      this._registerAnswerHandler(msgID, resolve, reject);
-    });
+  _unicast () {
+    return [ 'get', 'post', 'patch', 'delete' ];
   }
 
   _get (msg, reply, reject) {

--- a/src/fprotocol/foglet-resource.js
+++ b/src/fprotocol/foglet-resource.js
@@ -1,0 +1,64 @@
+/*
+MIT License
+
+Copyright (c) 2016-2017 Grall Arnaud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+'use strict';
+
+const FogletProtcol = require('./foglet-protocol.js');
+
+class FogletResource extends FogletProtcol {
+  constructor (name, foglet) {
+    super(foglet);
+    this._namespace = `resource/${name}`;
+    this.unicast()
+    .service('get', this._get)
+    .service('post', this._post)
+    .service('patch', this._patch)
+    .service('delete', this._delete);
+  }
+
+  get (id) {
+    return new Promise((resolve, reject) => {
+      const msgID = someRandomID();
+      this.unicast(id).call('get');
+      this._registerAnswerHandler(msgID, resolve, reject);
+    });
+  }
+
+  _get (msg, reply, reject) {
+    reject(new Error('implement a get method'));
+  }
+
+  _post (msg, reply, reject) {
+    reject(new Error('implement a post method'));
+  }
+
+  _patch (msg, reply, reject) {
+    reject(new Error('implement a patch method'));
+  }
+
+  _delete (msg, reply, reject) {
+    reject(new Error('implement a delete method'));
+  }
+}
+
+module.exports = FogletResource;

--- a/src/fprotocol/foglet-resource.js
+++ b/src/fprotocol/foglet-resource.js
@@ -25,7 +25,53 @@ SOFTWARE.
 
 const FogletProtocol = require('./foglet-protocol.js');
 
+/**
+ * FogletResource is a simple protocol for interacting with a collection of resources using a REST interface.
+ * It supports four operations:
+ * * `get` to retrieve the resources
+ * * `insert` to insert a new resource
+ * * `update` to update a resource
+ * * `delete` to delete a resource
+ * You can simply extends this class and implements the correct handlers to get an easy-to-use resource
+ * in a fog application.
+ *
+ * **Note:** a `FogletResource` only defines a protocol to interact with the resource.
+ * Therefore, it's the developer task to handle all other aspect of the resource, like data consistency for example.
+ * @extends FogletProtocol
+ * @author Thomas Minier
+ * @example
+ * class StudentResource extends FogletResource {
+   constructor (foglet) {
+     super('students', foglet);
+     this._students = [];
+   }
+
+   _get (msg, reply) {
+     reply(this._students);
+   }
+
+   _insert (msg, reply) {
+     this._students.push(msg.student);
+     reply('new student inserted');
+   }
+
+   _update (msg, reply) {
+     this._students[msg.index] = msg.student;
+     reply('student updated');
+   }
+
+   _delete (msg, reply) {
+     this._students.splice(msg.index, 1);
+     reply('student deleted');
+   }
+ }
+ */
 class FogletResource extends FogletProtocol {
+  /**
+   * Constructor
+   * @param  {string} name - The resource's name
+   * @param  {Foglet} foglet - The foglet instance to use to communicate
+   */
   constructor (name, foglet) {
     super(`foglet-core/foglet-resource/${name}`, foglet);
   }
@@ -34,18 +80,46 @@ class FogletResource extends FogletProtocol {
     return [ 'get', 'insert', 'update', 'delete' ];
   }
 
+  /**
+   * Handle incoming GET requests from other peers
+   * @param  {*} msg  - The GET request message
+   * @param  {function} reply  - A function called to reply to the GET request
+   * @param  {function} reject - A function called to reject the GET request
+   * @return {void}
+   */
   _get (msg, reply, reject) {
     reject(new Error('A valid FogletResource must implement a get handler'));
   }
 
+  /**
+   * Handle incoming INSERT requests from other peers
+   * @param  {*} msg  - The INSERT request message
+   * @param  {function} reply  - A function called to reply to the INSERT request
+   * @param  {function} reject - A function called to reject the INSERT request
+   * @return {void}
+   */
   _insert (msg, reply, reject) {
     reject(new Error('A valid FogletResource must implement an insert handler'));
   }
 
+  /**
+   * Handle incoming UPDATE requests from other peers
+   * @param  {*} msg  - The UPDATE request message
+   * @param  {function} reply  - A function called to reply to the UPDATE request
+   * @param  {function} reject - A function called to reject the UPDATE request
+   * @return {void}
+   */
   _update (msg, reply, reject) {
     reject(new Error('A valid FogletResource must implement an update handler'));
   }
 
+  /**
+   * Handle incoming DELETE requests from other peers
+   * @param  {*} msg  - The DELETE request message
+   * @param  {function} reply  - A function called to reply to the DELETE request
+   * @param  {function} reject - A function called to reject the DELETE request
+   * @return {void}
+   */
   _delete (msg, reply, reject) {
     reject(new Error('A valid FogletResource must implement a delete handler'));
   }

--- a/src/fprotocol/handler-manager.js
+++ b/src/fprotocol/handler-manager.js
@@ -37,7 +37,8 @@ class HandlerManager {
     this._protocol = protocol;
     this._unicastHandlers = new Map();
     this._broadcastHandlers = new Map();
-    this._unicastHandlers.set('foglet-protocol/service-answers', '_answer');
+    this._unicastHandlers.set('foglet-protocol/service-answers/reply', '_answerReply');
+    this._unicastHandlers.set('foglet-protocol/service-answers/reject', '_answerReject');
   }
 
   /**
@@ -89,9 +90,8 @@ class HandlerManager {
         const reply = value => {
           this._protocol._foglet.sendUnicast({
             protocol: 'foglet-protocol',
-            method: 'service-answers',
+            method: 'service-answers/reply',
             payload: {
-              type: 'reply',
               answerID: msg.answerID,
               value
             }
@@ -100,9 +100,8 @@ class HandlerManager {
         const reject = value => {
           this._protocol._foglet.sendUnicast({
             protocol: 'foglet-protocol',
-            method: 'service-answers',
+            method: 'service-answers/reject',
             payload: {
-              type: 'reject',
               answerID: msg.answerID,
               value
             }
@@ -118,7 +117,6 @@ class HandlerManager {
   /**
    * Handle the reception of a broadcast message
    * @private
-   * @param {string} senderID - ID of the peer who send the message
    * @param {Object} msg - The message received
    * @return {void}
    */

--- a/src/fprotocol/handler-manager.js
+++ b/src/fprotocol/handler-manager.js
@@ -1,0 +1,134 @@
+/*
+MIT License
+
+Copyright (c) 2016-2017 Grall Arnaud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+'use strict';
+
+/**
+ * HandlerManager manage protocol handlers, i.e. forward messages to the correct handlers.
+ * It also generates the reply & reject helpers.
+ * @author Thomas Minier
+ */
+class HandlerManager {
+  /**
+   * Constructor
+   * @param {FogletProtcol} protocol - The protocol on which handlers must be registered
+   */
+  constructor (protocol) {
+    this._protocol = protocol;
+    this._unicastHandlers = new Map();
+    this._broadcastHandlers = new Map();
+    this._unicastHandlers.set('foglet-protocol/service-answers', '_answer');
+  }
+
+  /**
+   * Initiliaze the mananger and connect handlers
+   * @return {void}
+   */
+  init () {
+    this._protocol._foglet.onUnicast((id, msg) => this._handleUnicast(id, msg));
+    this._protocol._foglet.onBroadcast(msg => this._handleBroadcast(msg));
+  }
+
+  /**
+   * Register a handler for an unicast message
+   * @param {string} name - The service's name
+   * @param {string} handlerName - The name of the handler, i.e. the name of a protocol's method
+   * @return {void}
+   */
+  registerUnicastHandler (name, handlerName) {
+    if (!(handlerName in this._protocol))
+      throw new SyntaxError(`The handler '${handlerName}' is not defined in the prototype of the protocol ${this.protocol._name}`);
+    this._unicastHandlers.set(name, handlerName);
+  }
+
+  /**
+   * Register a handler for a broadcast message
+   * @param {string} name - The service's name
+   * @param {string} handlerName - The name of the handler, i.e. the name of a protocol's method
+   * @return {void}
+   */
+  registerBroadcastHandler (name, handlerName) {
+    if (!(handlerName in this._protocol))
+      throw new SyntaxError(`The handler '${handlerName}' is not defined in the prototype of the protocol ${this.protocol._name}`);
+    this._broadcastHandlers.set(name, handlerName);
+  }
+
+  /**
+   * Handle the reception of an unicast message
+   * @private
+   * @param {string} senderID - ID of the peer who send the message
+   * @param {Object} msg - The message received
+   * @return {void}
+   */
+  _handleUnicast (senderID, msg) {
+    const msgType = `${msg.protocol}/${msg.method}`;
+    if (this._unicastHandlers.has(msgType)) {
+      const handlerName = this._unicastHandlers.get(msgType);
+      // do not generate helpers for message emitted through the reply & reject helpers
+      if (msgType !== 'foglet-protocol/service-answers') {
+        const reply = value => {
+          this._protocol._foglet.sendUnicast({
+            protocol: 'foglet-protocol',
+            method: 'service-answers',
+            payload: {
+              type: 'reply',
+              answerID: msg.answerID,
+              value
+            }
+          }, senderID);
+        };
+        const reject = value => {
+          this._protocol._foglet.sendUnicast({
+            protocol: 'foglet-protocol',
+            method: 'service-answers',
+            payload: {
+              type: 'reject',
+              answerID: msg.answerID,
+              value
+            }
+          }, senderID);
+        };
+        this._protocol[handlerName](msg.payload, reply, reject);
+      } else {
+        this._protocol[handlerName](msg.payload);
+      }
+    }
+  }
+
+  /**
+   * Handle the reception of a broadcast message
+   * @private
+   * @param {string} senderID - ID of the peer who send the message
+   * @param {Object} msg - The message received
+   * @return {void}
+   */
+  _handleBroadcast (msg) {
+    const msgType = `${msg.protocol}/${msg.method}`;
+    if (this._broadcastHandlers.has(msgType)) {
+      const handlerName = this._broadcastHandlers.get(msgType);
+      this._protocol[handlerName](msg.payload);
+    }
+  }
+}
+
+module.exports = HandlerManager;

--- a/tests/fprotocol/foglet-protocol-test.js
+++ b/tests/fprotocol/foglet-protocol-test.js
@@ -75,6 +75,25 @@ describe('FogletProtocol', () => {
         .catch(done);
       });
     });
+
+    it('should allow peers to reject service calls', done => {
+      const foglets = buildFog(Foglet, 2);
+      let f1 = foglets[0], f2 = foglets[1];
+      const p1 = new UnicastProtocol(f1),
+      p2 = new UnicastProtocol(f2, (msg, reply, reject) => {
+        reject(msg + ' world!');
+      });
+
+      f1.connection(f2).then(() => {
+        const peers = f1.getNeighbours();
+        assert.equal(peers.length, 1);
+        p1.get(peers[0], 'Hello')
+        .catch(msg => {
+          assert.equal(msg, 'Hello world!');
+          done();
+        });
+      });
+    });
   });
 
   describe('#broadcast', () => {

--- a/tests/fprotocol/foglet-protocol-test.js
+++ b/tests/fprotocol/foglet-protocol-test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const Foglet = require('../../src/foglet.js').Foglet;
+const FogletProtocol = require('../../src/fprotocol/foglet-protocol.js');
+const buildFog = require('../utils.js').buildFog;
+
+class UnicastProtocol extends FogletProtocol {
+  constructor (foglet, callback, done) {
+    super('sample-protocol', foglet);
+    this._callback = callback;
+    this._done = done;
+  }
+
+  _unicast () {
+    return [ 'get' ];
+  }
+
+  _get (msg) {
+    if (this._callback) this._callback(msg);
+    if (this._done) this._done();
+  }
+}
+
+class BroadcastProtocol extends FogletProtocol {
+  constructor (foglet, callback, done) {
+    super('sample-protocol', foglet);
+    this._callback = callback;
+    this._done = done;
+  }
+
+  _broadcast () {
+    return [ 'get' ];
+  }
+
+  _get (msg) {
+    if (this._callback) this._callback(msg);
+    if (this._done) this._done();
+  }
+}
+
+describe('FogletProtocol', () => {
+  describe('#unicast', () => {
+    it('should receive messages from remote services', done => {
+      const foglets = buildFog(Foglet, 2);
+      let f1 = foglets[0], f2 = foglets[1];
+      const expected = 'Hello world!';
+      const p1 = new UnicastProtocol(f1),
+      p2 = new UnicastProtocol(f2, msg => {
+        assert.equal(msg, expected);
+      }, done);
+
+      f1.connection(f2).then(() => {
+        const peers = f1.getNeighbours();
+        assert.equal(peers.length, 1);
+        p1.get(peers[0], expected);
+      });
+    });
+  });
+
+  describe('#broadcast', () => {
+    it('should receive messages from remote services', done => {
+      const foglets = buildFog(Foglet, 2);
+      let f1 = foglets[0], f2 = foglets[1];
+      const expected = 'Hello world!';
+      const p1 = new BroadcastProtocol(f1),
+      p2 = new BroadcastProtocol(f2, msg => {
+        assert.equal(msg, expected);
+      }, done);
+
+      f1.connection(f2).then(() => {
+        p1.get(expected);
+      });
+    });
+  });
+});

--- a/tests/fprotocol/foglet-resource-test.js
+++ b/tests/fprotocol/foglet-resource-test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const Foglet = require('../../src/foglet.js').Foglet;
+const FogletResource = require('../../src/fprotocol/foglet-resource.js');
+const buildFog = require('../utils.js').buildFog;
+
+class StudentResource extends FogletResource {
+  constructor (foglet) {
+    super('students', foglet);
+    this._students = [];
+  }
+
+  _get (msg, reply) {
+    reply(this._students);
+  }
+
+  _insert (msg, reply) {
+    this._students.push(msg.student);
+    reply('new student inserted');
+  }
+
+  _update (msg, reply) {
+    this._students[msg.index] = msg.student;
+    reply('student updated');
+  }
+
+  _delete (msg, reply) {
+    this._students.splice(msg.index, 1);
+    reply('student deleted');
+  }
+}
+
+describe('FogletResource', () => {
+  it('should support foglet resource with get/insert/update/delete operations', done => {
+    const foglets = buildFog(Foglet, 2);
+    let f1 = foglets[0], f2 = foglets[1];
+    const s1 = new StudentResource(f1),
+      s2 = new StudentResource(f2);
+    f1.connection(f2).then(() => {
+      const peers = f1.getNeighbours();
+      assert.equal(peers.length, 1);
+      const peerID = peers[0];
+
+      s1.get(peerID)
+      .then(students => {
+        assert.equal(students.length, 0);
+        return s1.insert(peerID, { student: 'Bob the genious' });
+      })
+      .then(msg => {
+        assert.equal(msg, 'new student inserted');
+        return s1.get(peerID);
+      })
+      .then(students => {
+        assert.equal(students.length, 1);
+        assert.equal(students[0], 'Bob the genious');
+        return s1.update(peerID, { index: 0, student: 'Bob the classic student' });
+      })
+      .then(msg => {
+        assert.equal(msg, 'student updated');
+        return s1.get(peerID);
+      })
+      .then(students => {
+        assert.equal(students.length, 1);
+        assert.equal(students[0], 'Bob the classic student');
+        return s1.delete(peerID, { index: 0 });
+      })
+      .then(msg => {
+        assert.equal(msg, 'student deleted');
+        return s1.get(peerID);
+      })
+      .then(students => {
+        assert.equal(students.length, 0);
+        done();
+      })
+      .catch(done);
+    });
+  });
+});


### PR DESCRIPTION
With this pull request, I propose a simple high-level API to easily design custom protocols using foglet.

The idea is simple: to define a new protocol, you generaly end up having several messages types and a big `switch` clause on a listener (broadcast or unicast) to filter traffic.
Therefore, I propose `FogletProtocol`, a class where you only need to define the type of servies offered by the protocol and the corresponding message handlers.
I also added helpers to reply & reject incoming requests, to facilitate exchanges between peers.

Example:
```javascript
class SimpleUnicastProtocol extends FogletProtocol {

   _unicast () {
     return [ 'get' ];
   }

   _get (msg, reply, reject) {
     if (msg.number % 2 === 0)
        reply('you send an event number');
     else
        reject('you send an event number, it is not good!!!');
   }
 }

// in you foglet app code
const foglet = getSomeFoglet();
const peerID = getSomePeeerID();
const example = new SimpleUnicastProtocol('example protocol', foglet);

example.get(peerID, { number: 2)
  .then(console.log)
  .catch(console.log); 
```