### PR TITLE
Adjustements to FBroadcast

### DIFF
--- a/src/flib/abstract-broadcast.js
+++ b/src/flib/abstract-broadcast.js
@@ -27,7 +27,7 @@ const EventEmitter = require('events');
 const Unicast = require('unicast-definition');
 
 /**
- * AbstractBroadcast representes an abstract broadcast protocol
+ * AbstractBroadcast represents an abstract broadcast protocol.
  * @abstract
  * @extends EventEmitter
  * @author Thomas Minier
@@ -52,7 +52,7 @@ class AbstractBroadcast extends EventEmitter {
    * Send a message in broadcast
    * @param  {Object}  message  - The message to send
    * @param  {Boolean} [isReady=undefined]
-   * @return {[type]}
+   * @return {boolean}
    */
   send (message, isReady = undefined) {
     throw new Error('A valid broadcast protocol should implement a send method');

--- a/src/flib/abstract-broadcast.js
+++ b/src/flib/abstract-broadcast.js
@@ -1,0 +1,72 @@
+/*
+MIT License
+
+Copyright (c) 2016-2017 Grall Arnaud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+'use strict';
+
+const EventEmitter = require('events');
+const Unicast = require('unicast-definition');
+
+/**
+ * AbstractBroadcast representes an abstract broadcast protocol
+ * @abstract
+ * @extends EventEmitter
+ * @author Thomas Minier
+ */
+class AbstractBroadcast extends EventEmitter {
+  /**
+   * Constructor
+   * @param  {AbstractAdapter} source - The source RPS/overlay
+   * @param  {string} protocol - The name of the broadcast protocol
+   */
+  constructor (source, protocol) {
+    super();
+    this.source = source;
+    this.protocol = 'foglet-broadcast-protocol-' + protocol;
+    this.unicast = new Unicast(this.source.rps, {pid: this.protocol});
+    this.unicast.on(this.protocol, (id, message) => {
+      this._receiveMessage(id, message);
+    });
+  }
+
+  /**
+   * Send a message in broadcast
+   * @param  {Object}  message  - The message to send
+   * @param  {Boolean} [isReady=undefined]
+   * @return {[type]}
+   */
+  send (message, isReady = undefined) {
+    throw new Error('A valid broadcast protocol should implement a send method');
+  }
+
+  /**
+   * Handler executed when a message is recevied
+   * @param  {string} id  - Message issuer's ID
+   * @param  {Object} message - The message received
+   * @return {void}
+   */
+  _receiveMessage (id, message) {
+    throw new Error('A valid broadcast protocol should implement a _receiveMessage method');
+  }
+}
+
+module.exports = AbstractBroadcast;

--- a/src/flib/fbroadcast.js
+++ b/src/flib/fbroadcast.js
@@ -95,7 +95,7 @@ class FBroadcast extends AbstractBroadcast {
       // buffer of received messages
       this.buffer = [];
       // buffer of anti-entropy messages (chunkified because of large size)
-      this.bufferAntiEntropy = new MAntiEntropyResponse('init');
+      this.bufferAntiEntropy = MAntiEntropyResponse('init');
 
       debug(`initialized for:  ${this.options.protocol}`);
     } else {
@@ -202,9 +202,9 @@ class FBroadcast extends AbstractBroadcast {
    * @return {boolean} True if the message should not be propagated, False if it should be.
    */
   _shouldStopPropagation (message) {
-    const causalityLower = this.causality.isLower(message.id);
-    const messageAlreadyReceived = this._findInBuffer(formatID(message)) > -1;
-    return  causalityLower || messageAlreadyReceived;
+    if (this.causality.isLower(message.id))
+      return true;
+    return this._findInBuffer(formatID(message)) > -1;
   }
 
   /**

--- a/tests/fbroadcastTest.js
+++ b/tests/fbroadcastTest.js
@@ -45,15 +45,18 @@ describe('[FBROADCAST] functions', function () {
 
   it('[FBROADCAST] sendBroadcast/onBroadcast', function (done) {
     const foglets = buildFog(Foglet, 2);
+    let neighbourID = null;
     let f1 = foglets[0], f2 = foglets[1];
 
-    f2.onBroadcast((data) => {
+    f2.onBroadcast((data, id) => {
       console.log(data);
       assert.equal(data, 'hello');
+      assert.equal(id, neighbourID);
       done();
     });
 
-    f1.connection(f2).then( () => {
+    f1.connection(f2).then(() => {
+      neighbourID = f1.outviewId;
       setTimeout(function () {
         f1.sendBroadcast('hello');
       }, 2000);


### PR DESCRIPTION
Some adjustements to FBroadcast:
* The ID of the peer who issued a broadcast message is now available in `Foglet#onBroadcast` callback.
* Use a sorted buffer + binary search algorithm when checking for messages already received.
* Add an abstract class to define broadcast protocols (FBroadcast now implements it) and move up some shared behviour.
* Add basic jsdoc in `FBroadcast` class.

Have fun :octocat: